### PR TITLE
avoid assigning null to IMG.src on detach

### DIFF
--- a/Od/Examples/DbMonsterOd/app.js
+++ b/Od/Examples/DbMonsterOd/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Examples/DemoEndsElements/app.js
+++ b/Od/Examples/DemoEndsElements/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Examples/DemoEndsSelectComponent/app.js
+++ b/Od/Examples/DemoEndsSelectComponent/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Examples/DemoEndsTabComponent/app.js
+++ b/Od/Examples/DemoEndsTabComponent/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Examples/DemoOd/app.js
+++ b/Od/Examples/DemoOd/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Examples/DemoOdLifecycle/app.js
+++ b/Od/Examples/DemoOdLifecycle/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Examples/DemoOdLifecycle2/app.js
+++ b/Od/Examples/DemoOdLifecycle2/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Examples/OdThreadIt/app.js
+++ b/Od/Examples/OdThreadIt/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Examples/ToDoMvcOd/app.js
+++ b/Od/Examples/ToDoMvcOd/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/MinJs/ObsAndOd.js
+++ b/Od/MinJs/ObsAndOd.js
@@ -1008,6 +1008,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/MinJs/ObsAndOdAndElements.js
+++ b/Od/MinJs/ObsAndOdAndElements.js
@@ -1008,6 +1008,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/MinJs/Od.js
+++ b/Od/MinJs/Od.js
@@ -581,6 +581,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/MinJs/OdAndEnds.js
+++ b/Od/MinJs/OdAndEnds.js
@@ -1008,6 +1008,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Od/Od.js
+++ b/Od/Od/Od.js
@@ -581,6 +581,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Od/Od.ts
+++ b/Od/Od/Od.ts
@@ -658,6 +658,7 @@ namespace Od {
         const props = getEltOdProps(dom);
         const lifecycleFn = odEventHandler(props);
         if (lifecycleFn) lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG') delete props['src'];
         for (var prop in props) (dom as any)[prop] = null;
         // Recursively strip any child nodes.
         const children = dom.childNodes;

--- a/Od/Tests/TestEndsPromise/app.js
+++ b/Od/Tests/TestEndsPromise/app.js
@@ -1134,6 +1134,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Tests/TestMihaiDisposalLifecycle/app.js
+++ b/Od/Tests/TestMihaiDisposalLifecycle/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Tests/TestMihaiGarbageRetention/app.js
+++ b/Od/Tests/TestMihaiGarbageRetention/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.

--- a/Od/Tests/TestOd/app.js
+++ b/Od/Tests/TestOd/app.js
@@ -1007,6 +1007,8 @@ var Od;
         var lifecycleFn = odEventHandler(props);
         if (lifecycleFn)
             lifecycleFn("removed", dom);
+        if (dom.tagName === 'IMG')
+            delete props['src'];
         for (var prop in props)
             dom[prop] = null;
         // Recursively strip any child nodes.


### PR DESCRIPTION
Setting the `src` of an `IMG` element causes it to go and look for that data, even if the value is null.

Maybe it is not the best implementation but I just wanted to officially contribute to this awesome project. :)
